### PR TITLE
Update RandomX and fix library search path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use std::env;
 fn main() {
     let dst = Config::new("RandomX").define("DARCH", "native").build();
 
-    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-search=native={}/build", dst.display());
     println!("cargo:rustc-link-lib=static=randomx");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("linux".to_string());


### PR DESCRIPTION
This pull request addresses a compilation issue caused by a missing export in the RandomX library. Updating RandomX to version 102f8acf90a7649ada410de5499a7ec62e49e1da resolves the export issue. Additionally, a necessary adjustment to the library search path ensures successful compilation.