### PR TITLE
Remove Unnecessary Dependencies: num_cpus and rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ license = "MIT"
 cmake = "0.1"
 
 [dependencies]
-rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ license = "MIT"
 cmake = "0.1"
 
 [dependencies]
-num_cpus = "1.0"
 rand = "0.8.5"

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use std::env;
 fn main() {
     let dst = Config::new("RandomX").define("DARCH", "native").build();
 
-    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-search=native={}/build", dst.display());
     println!("cargo:rustc-link-lib=static=randomx");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("linux".to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use num_cpus;
 use std::os::raw::c_void;
 use std::sync::Arc;
 use std::thread;
@@ -173,7 +172,7 @@ impl Context {
             if fast {
                 flags = flags | randomx_flags_RANDOMX_FLAG_FULL_MEM;
                 dataset = randomx_alloc_dataset(flags);
-                let num_threads = num_cpus::get();
+                let num_threads = thread::available_parallelism().expect("Failed to determine available parallelism").get();
                 let length = randomx_dataset_item_count() as usize / num_threads;
                 let mut threads = Vec::new();
                 for i in 0..num_threads {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use num_cpus;
 use rand::prelude::*;
 use rust_randomx::{Context, Difficulty, Hasher};
 use std::sync::Arc;
@@ -7,7 +6,7 @@ use std::thread;
 fn main() {
     let context = Arc::new(Context::new(b"RandomX key", true));
 
-    let num_threads = num_cpus::get();
+    let num_threads = thread::available_parallelism().expect("Failed to determine available parallelism").get();
     let mut threads = Vec::new();
     for _ in 0..num_threads {
         let context = Arc::clone(&context);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use rand::prelude::*;
 use rust_randomx::{Context, Difficulty, Hasher};
 use std::sync::Arc;
 use std::thread;
@@ -8,16 +7,15 @@ fn main() {
 
     let num_threads = thread::available_parallelism().expect("Failed to determine available parallelism").get();
     let mut threads = Vec::new();
-    for _ in 0..num_threads {
+    for i in 0..num_threads {
         let context = Arc::clone(&context);
         let diff = Difficulty::new(0x027fffff); // 0x00007fff ff000000 ... 00000000
         threads.push(thread::spawn(move || {
-            let mut rng = rand::thread_rng();
             let mut hasher = Hasher::new(context);
-            let mut nonce: u32 = rng.gen();
+            let mut nonce = i as u32;
             hasher.hash_first(&nonce.to_le_bytes());
-            loop {
-                let next_nonce: u32 = rng.gen();
+            while nonce < u32::MAX {
+                let next_nonce = nonce.saturating_add(num_threads as u32);
                 let out = hasher.hash_next(&next_nonce.to_le_bytes());
                 if out.meets_difficulty(diff) {
                     println!("{} -> {:?}", nonce, out);


### PR DESCRIPTION
This pull request aims to optimize dependencies and make code more efficient by removing two unnecessary crates:  
* `num_cpus`: We can effectively replace this crate with `std::thread::available_parallelism()` from the standard library, achieving the same functionality without the external dependency.  
* `rand`: By removing the `rand` crate and changing the `main.rs` file, we can eliminate the possibility of repeated calculations due to random number collisions. Additionally, this change ensures that threads only perform identical work in certain scenarios (when `new_nonce` is `u32::MAX`)